### PR TITLE
Fix(accessibility): Ensure font reset button reverts to CSS value

### DIFF
--- a/script.js
+++ b/script.js
@@ -45,7 +45,6 @@ function initAccessibilityControls() {
   }
 
   // Font size controls
-  const baseFontSize = 16;
   const minFontSize = 12;
   const maxFontSize = 24;
 
@@ -58,7 +57,7 @@ function initAccessibilityControls() {
   });
 
   document.getElementById('font-reset')?.addEventListener('click', function() {
-    document.documentElement.style.fontSize = baseFontSize + 'px';
+    document.documentElement.style.removeProperty('font-size');
     localStorage.removeItem('fontSize');
   });
 


### PR DESCRIPTION
The font reset button in the accessibility controls was hardcoded to reset the font size to 16px. This behavior is incorrect as it does not respect the fluid typography defined in the CSS, which can specify a different base font size depending on the viewport.

This commit fixes the issue by changing the reset button's functionality. Instead of setting a hardcoded font size, it now removes the inline `font-size` style from the `<html>` element. This allows the browser to correctly fall back to the value defined in the site's stylesheet, restoring the intended responsive font size.